### PR TITLE
Add helper script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,7 @@ RUN echo "Getting Packages..." && \
     echo "Fixing Permissions..." && \
     chmod +x /usr/bin/overdrive && \
     echo "All done"
+
+COPY run-overdrive.sh /usr/bin/run-overdrive
+
+RUN chmod +x /usr/bin/run-overdrive

--- a/run-overdrive.sh
+++ b/run-overdrive.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ ! -z $DESTINATION_FOLDER ]]; then
+    cd $DESTINATION_FOLDER
+fi
+
+SOURCE_PREPEND=""
+
+if [[ ! -z $SOURCE_FOLDER ]]; then
+    SOURCE_PREPEND=$DESTINATION_FOLDER/
+fi
+
+/usr/bin/overdrive "$1" "$SOURCE_PREPEND$2"


### PR DESCRIPTION
This adds a helper script that reads environment variables $DESTINATION_FOLDER and $SOURCE_FOLDER so that all that needs to be passed to the underlying overdrive script is the filename (with extension).

Call via `run-overdrive` instead of `overdrive`.