### PR TITLE
Deprecate ARMv7

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
 
       - name: Docker Meta
         id: meta
@@ -71,7 +69,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm64,linux/amd64
+          provenance: false
           push: ${{ env.SHOULD_PUBLISH }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Docker Meta
         id: meta

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
 
       - name: Docker Meta
         id: meta

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v2
-        with:
-          platforms: linux/amd64,linux/arm64
 
       - name: Docker Meta
         id: meta
@@ -71,7 +69,8 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm64,linux/amd64
+          provenance: false
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The upstream image for Alpine (LSIO) has dropped support for ARMv7. This has been [long scheduled](https://www.linuxserver.io/blog/end-of-an-arch) but it finally coming to fruition (all of their images will no longer support come [2023-07-01](https://info.linuxserver.io/issues/2023-05-06-armhf/)).

This also updates to hopefully remove `unknown/unkown` OS in GHCR.